### PR TITLE
Fix mobile display and adjust layout breakpoint

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -152,7 +152,7 @@ body.no-scroll {
 /* --- Base Styles --- */
 .hero {
     position: relative;
-    height: 90vh;
+    height: 100vh;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -239,21 +239,21 @@ main section {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    gap: 10px;
+    gap: 5px;
     text-align: center;
-    font-size: 0.8rem;
+    font-size: 0.7rem;
 }
 
 #timer > div {
     background: rgba(255, 255, 255, 0.1);
-    padding: 10px;
+    padding: 8px;
     border-radius: 5px;
-    min-width: 70px;
+    min-width: 60px;
 }
 
 #timer span {
     display: block;
-    font-size: 2rem;
+    font-size: 1.8rem;
     font-weight: 700;
 }
 
@@ -333,7 +333,7 @@ footer {
 .scroll-reveal {
     opacity: 0;
     transform: translateY(30px);
-    transition: opacity 0.8s cubic-bezier(0.25, 0.1, 0.25, 1), transform 0.8s cubic-bezier(0.25, 0.1, 0.25, 1);
+    transition: opacity 1.4s cubic-bezier(0.25, 0.1, 0.25, 1), transform 1.4s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 
 .scroll-reveal.is-visible {
@@ -342,7 +342,7 @@ footer {
 }
 
 /* --- Tablet and Up --- */
-@media (min-width: 768px) {
+@media (min-width: 830px) {
     .menu-toggle {
         display: none;
     }
@@ -372,7 +372,6 @@ footer {
     }
 
     .hero {
-        height: 100vh;
     }
 
     .hero-content h1 {


### PR DESCRIPTION
This commit addresses several display issues, primarily for mobile and tablet views.

- Sets the hero section height to 100vh on all devices to ensure it fills the screen correctly on mobile.
- Adjusts the scroll reveal animation duration to 1.4s as requested.
- Fixes the countdown timer layout on mobile by reducing its size to prevent wrapping. The timer remains large on desktop screens.
- Adjusts the media query breakpoint from 768px to 830px to prevent layout issues on tablet-sized screens.